### PR TITLE
Add `gekko_remove_actor` by net address

### DIFF
--- a/GekkoLib/include/gekko.h
+++ b/GekkoLib/include/gekko.h
@@ -16,7 +16,7 @@ struct GekkoSession {
     virtual void SetLocalDelay(i32 player, u8 delay) = 0;
     virtual void SetNetAdapter(GekkoNetAdapter* adapter) = 0;
     virtual i32 AddActor(GekkoPlayerType type, GekkoNetAddress* addr) = 0;
-    virtual void RemoveActor(const GekkoNetAddress* addr) = 0;
+    virtual void RemoveActor(GekkoNetAddress addr) = 0;
     virtual void AddLocalInput(i32 player, void* input) = 0;
     virtual GekkoGameEvent** UpdateSession(i32* count) = 0;
     virtual GekkoSessionEvent** Events(i32* count) = 0;
@@ -40,7 +40,7 @@ namespace Gekko {
 
         virtual i32 AddActor(GekkoPlayerType type, GekkoNetAddress* addr);
 
-        virtual void RemoveActor(const GekkoNetAddress* addr);
+        virtual void RemoveActor(GekkoNetAddress addr);
 
         virtual void AddLocalInput(i32 player, void* input);
 

--- a/GekkoLib/include/gekko.h
+++ b/GekkoLib/include/gekko.h
@@ -16,6 +16,7 @@ struct GekkoSession {
     virtual void SetLocalDelay(i32 player, u8 delay) = 0;
     virtual void SetNetAdapter(GekkoNetAdapter* adapter) = 0;
     virtual i32 AddActor(GekkoPlayerType type, GekkoNetAddress* addr) = 0;
+    virtual void RemoveActor(i32 player) = 0;
     virtual void AddLocalInput(i32 player, void* input) = 0;
     virtual GekkoGameEvent** UpdateSession(i32* count) = 0;
     virtual GekkoSessionEvent** Events(i32* count) = 0;
@@ -38,6 +39,8 @@ namespace Gekko {
         virtual void SetNetAdapter(GekkoNetAdapter* adapter);
 
         virtual i32 AddActor(GekkoPlayerType type, GekkoNetAddress* addr);
+
+        virtual void RemoveActor(i32 player);
 
         virtual void AddLocalInput(i32 player, void* input);
 

--- a/GekkoLib/include/gekko.h
+++ b/GekkoLib/include/gekko.h
@@ -16,7 +16,7 @@ struct GekkoSession {
     virtual void SetLocalDelay(i32 player, u8 delay) = 0;
     virtual void SetNetAdapter(GekkoNetAdapter* adapter) = 0;
     virtual i32 AddActor(GekkoPlayerType type, GekkoNetAddress* addr) = 0;
-    virtual void RemoveActor(i32 player) = 0;
+    virtual void RemoveActor(const GekkoNetAddress* addr) = 0;
     virtual void AddLocalInput(i32 player, void* input) = 0;
     virtual GekkoGameEvent** UpdateSession(i32* count) = 0;
     virtual GekkoSessionEvent** Events(i32* count) = 0;
@@ -40,7 +40,7 @@ namespace Gekko {
 
         virtual i32 AddActor(GekkoPlayerType type, GekkoNetAddress* addr);
 
-        virtual void RemoveActor(i32 player);
+        virtual void RemoveActor(const GekkoNetAddress* addr);
 
         virtual void AddLocalInput(i32 player, void* input);
 

--- a/GekkoLib/include/gekkonet.h
+++ b/GekkoLib/include/gekkonet.h
@@ -178,7 +178,7 @@ GEKKONET_API void gekko_net_adapter_set(GekkoSession* session, GekkoNetAdapter* 
 
 GEKKONET_API int gekko_add_actor(GekkoSession* session, GekkoPlayerType player_type, GekkoNetAddress* addr);
 
-GEKKONET_API void gekko_remove_actor(GekkoSession* session, int player);
+GEKKONET_API void gekko_remove_actor(GekkoSession* session, const GekkoNetAddress* addr);
 
 GEKKONET_API void gekko_set_local_delay(GekkoSession* session, int player, unsigned char delay);
 

--- a/GekkoLib/include/gekkonet.h
+++ b/GekkoLib/include/gekkonet.h
@@ -178,7 +178,7 @@ GEKKONET_API void gekko_net_adapter_set(GekkoSession* session, GekkoNetAdapter* 
 
 GEKKONET_API int gekko_add_actor(GekkoSession* session, GekkoPlayerType player_type, GekkoNetAddress* addr);
 
-GEKKONET_API void gekko_remove_actor(GekkoSession* session, const GekkoNetAddress* addr);
+GEKKONET_API void gekko_remove_actor(GekkoSession* session, GekkoNetAddress addr);
 
 GEKKONET_API void gekko_set_local_delay(GekkoSession* session, int player, unsigned char delay);
 

--- a/GekkoLib/include/gekkonet.h
+++ b/GekkoLib/include/gekkonet.h
@@ -104,7 +104,7 @@ typedef struct GekkoGameEvent {
     GekkoGameEventType type;
 
     union EventData {
-        // events 
+        // events
         struct Advance {
             int frame;
             unsigned int input_len;
@@ -177,6 +177,8 @@ GEKKONET_API void gekko_start(GekkoSession* session, GekkoConfig* config);
 GEKKONET_API void gekko_net_adapter_set(GekkoSession* session, GekkoNetAdapter* adapter);
 
 GEKKONET_API int gekko_add_actor(GekkoSession* session, GekkoPlayerType player_type, GekkoNetAddress* addr);
+
+GEKKONET_API void gekko_remove_actor(GekkoSession* session, int player);
 
 GEKKONET_API void gekko_set_local_delay(GekkoSession* session, int player, unsigned char delay);
 

--- a/GekkoLib/src/gekko.cpp
+++ b/GekkoLib/src/gekko.cpp
@@ -102,6 +102,22 @@ i32 Gekko::Session::AddActor(GekkoPlayerType type, GekkoNetAddress* addr)
     }
 }
 
+void Gekko::Session::RemoveActor(i32 player)
+{
+    for (const auto& local : _msg.locals) {
+        if (local->handle == player) {
+            local->SetStatus(Disconnected);
+            return;
+        }
+    }
+    for (const auto& remote : _msg.remotes) {
+        if (remote->handle == player) {
+            remote->SetStatus(Disconnected);
+            return;
+        }
+    }
+}
+
 void Gekko::Session::AddLocalInput(i32 player, void* input)
 {
     u8* inp = (u8*)input;

--- a/GekkoLib/src/gekko.cpp
+++ b/GekkoLib/src/gekko.cpp
@@ -102,16 +102,11 @@ i32 Gekko::Session::AddActor(GekkoPlayerType type, GekkoNetAddress* addr)
     }
 }
 
-void Gekko::Session::RemoveActor(i32 player)
+void Gekko::Session::RemoveActor(const GekkoNetAddress* addr)
 {
-    for (const auto& local : _msg.locals) {
-        if (local->handle == player) {
-            local->SetStatus(Disconnected);
-            return;
-        }
-    }
+    NetAddress net_addr(addr->data, addr->size);
     for (const auto& remote : _msg.remotes) {
-        if (remote->handle == player) {
+        if (remote->address.Equals(net_addr)) {
             remote->SetStatus(Disconnected);
             return;
         }

--- a/GekkoLib/src/gekko.cpp
+++ b/GekkoLib/src/gekko.cpp
@@ -105,9 +105,10 @@ i32 Gekko::Session::AddActor(GekkoPlayerType type, GekkoNetAddress* addr)
 void Gekko::Session::RemoveActor(GekkoNetAddress addr)
 {
     NetAddress net_addr(addr.data, addr.size);
-    for (const auto& remote : _msg.remotes) {
-        if (remote->address.Equals(net_addr)) {
-            remote->SetStatus(Disconnected);
+    for (const auto& player : _msg.remotes) {
+        if (player->address.Equals(net_addr)) {
+            _msg.session_events.AddPlayerDisconnectedEvent(player->handle);
+            player->SetStatus(Disconnected);
             return;
         }
     }

--- a/GekkoLib/src/gekko.cpp
+++ b/GekkoLib/src/gekko.cpp
@@ -102,9 +102,9 @@ i32 Gekko::Session::AddActor(GekkoPlayerType type, GekkoNetAddress* addr)
     }
 }
 
-void Gekko::Session::RemoveActor(const GekkoNetAddress* addr)
+void Gekko::Session::RemoveActor(GekkoNetAddress addr)
 {
-    NetAddress net_addr(addr->data, addr->size);
+    NetAddress net_addr(addr.data, addr.size);
     for (const auto& remote : _msg.remotes) {
         if (remote->address.Equals(net_addr)) {
             remote->SetStatus(Disconnected);

--- a/GekkoLib/src/gekkonet.cpp
+++ b/GekkoLib/src/gekkonet.cpp
@@ -36,9 +36,9 @@ int gekko_add_actor(GekkoSession* session, GekkoPlayerType player_type, GekkoNet
     return session->AddActor(player_type, !addr ? nullptr : addr);
 }
 
-void gekko_remove_actor(GekkoSession* session, int player)
+void gekko_remove_actor(GekkoSession* session, const GekkoNetAddress* addr)
 {
-    session->RemoveActor(player);
+    session->RemoveActor(addr);
 }
 
 void gekko_set_local_delay(GekkoSession* session, int player, unsigned char delay)

--- a/GekkoLib/src/gekkonet.cpp
+++ b/GekkoLib/src/gekkonet.cpp
@@ -36,7 +36,7 @@ int gekko_add_actor(GekkoSession* session, GekkoPlayerType player_type, GekkoNet
     return session->AddActor(player_type, !addr ? nullptr : addr);
 }
 
-void gekko_remove_actor(GekkoSession* session, const GekkoNetAddress* addr)
+void gekko_remove_actor(GekkoSession* session, GekkoNetAddress addr)
 {
     session->RemoveActor(addr);
 }

--- a/GekkoLib/src/gekkonet.cpp
+++ b/GekkoLib/src/gekkonet.cpp
@@ -36,6 +36,11 @@ int gekko_add_actor(GekkoSession* session, GekkoPlayerType player_type, GekkoNet
     return session->AddActor(player_type, !addr ? nullptr : addr);
 }
 
+void gekko_remove_actor(GekkoSession* session, int player)
+{
+    session->RemoveActor(player);
+}
+
 void gekko_set_local_delay(GekkoSession* session, int player, unsigned char delay)
 {
     session->SetLocalDelay(player, delay);


### PR DESCRIPTION
Not sure if it's necessary, but I found this really handy inside custom network adapters for handling graceful disconnections without waiting for them to time out.

My only concern is having to issue these outside the usual `GekkoNetAdapter`'s `send_data`/`receive_data` loop due to requiring a handle to `GekkoSession`. That wasn't a problem for my specific usecase, but it could be for others.

Let me know if anything needs to be changed.